### PR TITLE
Removes program number in `usage`

### DIFF
--- a/src/__tests__/__snapshots__/index.ts.snap
+++ b/src/__tests__/__snapshots__/index.ts.snap
@@ -25,7 +25,7 @@ exports[`cli should print status when no errors 1`] = `
 
 exports[`cli should print usage without args 1`] = `
 "
-  Usage: index mcritic [options] <path>
+  Usage: index [options] <path>
 
 
   Options:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ const pkg = require('../package.json');
 export async function main(argv: Array<string>): Promise<void> {
   const cli = program
     .version(pkg.version)
-    .usage('mcritic [options] <path>')
+    .usage('[options] <path>')
     .option('-i, --ignore <ignore>', 'A glob to ignore files, if passed a directory')
     .option('-v, --verbose', 'Output for all files')
     .parse(argv);


### PR DESCRIPTION
Program already uses the program number when printing the usage message, so right now, it should be showing `Usage: mcritic mcritic [options] <path>`